### PR TITLE
add: darksilver

### DIFF
--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -10,6 +10,7 @@
   --clr-darkgray: #333;
   --clr-gray: #757575;
   --clr-lightgray: #858585;
+  --clr-darksilver: #aaa;
   --clr-dimsilver: #ccc;
   --clr-silver: #e2e2e2;
   --clr-lightsilver: #efefef;


### PR DESCRIPTION
Updated docs:
https://company-84672.frontify.com/document/151334#/basics/colors

入力要素のplaceholderのテキストに使う色に、これまで `#999999` を使っていたものの、廃止に伴い適当な色がなくなったため、追加しました。
その他、非活性なボタンなど、「読まれなくてもいいテキスト」にも使われる想定です。

### 詳細

[1.4.3 テキストや文字画像のコントラストを確保する](https://openameba.github.io/a11y-guidelines/1/4/3/) では、テキスト色と背景色の間には4.5:1のコントラストを保つ必要があります。
そのため、WCAG2.0に則ると（下記引用）、本来はplaceholderテキストに `#aaaaaa` の色は使うことはできません。

> 最低限のコントラスト (1.4.3) 達成基準は、プレースホルダーテキストおよびオブジェクトにポインターをかざされたりキーボードフォーカスされた時に表示されるテキストを含め、ページ内のテキストに適用される。そのようなテキストを使用するのであれば、十分なコントラストを提供する必要がある。
https://waic.jp/docs/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html

しかしそもそもplaceholderのテキストに「読まなければUIを使うことができない文字」を載せること自体がアクセシビリティ的に良いものではありません（入力中に読むことができないことで、目的を達成できないユーザーができてしまうため）。

そのため、「placeholderテキストがなくても意味が通じる配置」をとる前提で、placeholderテキストに `#aaaaaa` を使うことを定義しました。

代わりに、これまで用途が曖昧だった `#cccccc` は非推奨とします。（多用されているため、現状廃止にはできないので、他色への置き換えを推奨します）


---

参考： [Color Contrast Grid](http://contrast-grid.eightshapes.com/?background-colors=&foreground-colors=%23333333%2CMain%20Text%0D%0A%23757575%2CSub%20Text%0D%0A%23858585%2CBgcolor%2CBorder%2CIcon%0D%0A%23aaaaaa%2C%20placeholder%E6%96%87%E3%80%81disabled%0D%0A%23cccccc%2C%20%E2%80%BB%23aaa%E3%82%84%E4%BB%96%E8%89%B2%E6%8E%A8%E5%A5%A8%0D%0A%23e2e2e2%2C%20%E3%83%A9%E3%82%A4%E3%83%B3%E8%89%B2%0D%0A%23efefef%2C%20%E8%83%8C%E6%99%AF%E8%89%B2%0D%0A%23f8f8f8%2C%20placeholder%E3%81%AE%E5%A1%97%E3%82%8A%E8%89%B2%0D%0A%23ffffff%0D%0A%232D8C3C%2CGreen%0D%0A%2349C755%2CLight%20Green%0D%0A%234290C6%2CBlue%0D%0A%2358B8EF%2CLight%20Blue%0D%0A%23FF547C%2C%20Pink%0D%0A%23F24C3B%2CRed%0D%0A%23FE9019%2COrange%0D%0A%23F8CD21%2CYellow%0D%0A%23FCFAE8%2CLight%20Yellow%E2%80%BB%E9%87%8D%E8%A6%81%E3%81%AA%E9%80%9A%E7%9F%A5%E6%99%82%0D%0A%23CEA65C%2CGold%0D%0A%23B98353%2CBronze%0D%0A%23666666%2CDeprecated%0D%0A%23999999%2CDeprecated&es-color-form__tile-size=compact) にも追加しました。