### PR TITLE
Add dark green color

### DIFF
--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -18,6 +18,7 @@
   --clr-white: #fff;
 
   /* Colors */
+  --clr-darkgreen: #298538;
   --clr-green: #2d8c3c;
   --clr-lightgreen: #49c755;
   --clr-blue: #4290c6;


### PR DESCRIPTION
The dark green color has enough contrast ratio (WCAG AA), so you can use this as text color on white background. DO NOT use the green color as text.