### PR TITLE
Add dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+version: 1
+
+update_configs:
+  - package_manager: javascript
+    directory: /
+    update_schedule: weekly
+    default_assignees:
+      - herablog
+      - sasaplus1
+      - tokimari
+    default_labels:
+      - dependabot
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: all

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ameba-color-palette.css
 
 [![Build Status](https://travis-ci.org/openameba/ameba-color-palette.css.svg?branch=master)](https://travis-ci.org/openameba/ameba-color-palette.css)
+[![dependabot](https://api.dependabot.com/badges/status?host=github&repo=openameba/ameba-color-palette.css)](https://dependabot.com)
 
 Ameba Color Palette.
 


### PR DESCRIPTION
dependabotで自動的にモジュールのアップデートをしてもらえるようにしました。

https://dependabot.com/docs/config-file/validator/

で設定ファイルの検査をしたので設定は大丈夫かと思います。

ドキュメントはこちら: https://dependabot.com/docs/config-file/

- [ ] リポジトリにdependabotの連携をする

> Alternatively, you can configure Dependabot by adding a .dependabot/config.yml file to a repo.

とあるので連携しなくてもよい🤔?