### PR TITLE
use files field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-.editorconfig
-.stylelintrc.json
-.travis.yml

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "devDependencies": {
     "stylelint": "^9.5.0",
     "stylelint-config-standard": "^18.2.0"
-  }
+  },
+  "files": [
+    "ameba-color-palette.css"
+  ]
 }


### PR DESCRIPTION
`.npmignore`でファイルを除外するよりも`files`フィールドで追加したいファイルを指定する方がよいだろうと思ったので独善的にPRを作っています。

see: [細かすぎて伝わらない package.json 小ネタ三選 - Tips1: package.json の files フィールドでホワイトリスト](https://t-wada.hatenablog.jp/entry/nodejs-package-json-tips)

`npm pack`でpublishした時のtgzが作れるのでそれでファイルが格納されるかどうかを確認しました。

### `.npmignore`削除直後

```console
$ npm pack
npm notice
npm notice ameba-color-palette.css@2.3.0
npm notice === Tarball Contents ===
npm notice 195B  .editorconfig
npm notice 1.1kB LICENSE
npm notice 1.0kB ameba-color-palette.css
npm notice 45B   .stylelintrc.json
npm notice 634B  package.json
npm notice 866B  README.md
npm notice 33B   .travis.yml
npm notice === Tarball Details ===
npm notice name:          ameba-color-palette.css
npm notice version:       2.3.0
npm notice filename:      ameba-color-palette.css-2.3.0.tgz
npm notice package size:  2.1 kB
npm notice unpacked size: 3.9 kB
npm notice shasum:        686d34eeba821a62b1a51f420b7b948dbec9f994
npm notice integrity:     sha512-yLZFudovLGVcI[...]gMgT7Tsc1l3Uw==
npm notice total files:   7
npm notice
ameba-color-palette.css-2.3.0.tgz
$ tar tvf ameba-color-palette.css-2.3.0.tgz
-rw-r--r--  0 0      0         195 10 26  1985 package/.editorconfig
-rw-r--r--  0 0      0        1066 10 26  1985 package/LICENSE
-rw-r--r--  0 0      0        1026 10 26  1985 package/ameba-color-palette.css
-rw-r--r--  0 0      0          45 10 26  1985 package/.stylelintrc.json
-rw-r--r--  0 0      0         634 10 26  1985 package/package.json
-rw-r--r--  0 0      0         866 10 26  1985 package/README.md
-rw-r--r--  0 0      0          33 10 26  1985 package/.travis.yml

```

### `files`フィールド追加直後

```console
$ npm pack
npm notice
npm notice ameba-color-palette.css@2.3.0
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 1.0kB ameba-color-palette.css
npm notice 682B  package.json
npm notice 866B  README.md
npm notice === Tarball Details ===
npm notice name:          ameba-color-palette.css
npm notice version:       2.3.0
npm notice filename:      ameba-color-palette.css-2.3.0.tgz
npm notice package size:  1.8 kB
npm notice unpacked size: 3.6 kB
npm notice shasum:        5675caea726bed0ac51cccc6dfbe47077b3d5272
npm notice integrity:     sha512-rjEZIKWb+zgZD[...]7s6QB/3snA3nQ==
npm notice total files:   4
npm notice
ameba-color-palette.css-2.3.0.tgz
$ tar tvf ameba-color-palette.css-2.3.0.tgz
-rw-r--r--  0 0      0        1066 10 26  1985 package/LICENSE
-rw-r--r--  0 0      0        1026 10 26  1985 package/ameba-color-palette.css
-rw-r--r--  0 0      0         682 10 26  1985 package/package.json
-rw-r--r--  0 0      0         866 10 26  1985 package/README.md

```

ちなみに、`main`に`ameba-color-palette.css`が指定されているからなのか、実は`"files": []`でも「`files`フィールド追加直後」と同様の結果が得られました……