### PR TITLE
feat: add overlay color

### DIFF
--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -157,6 +157,11 @@
   --color-object-high-emphasis-inverse: var(--white-100);
   --color-object-expressive-pink: var(--expressive-pink);
 
+  /* Overlay Colors */
+  --color-overlay-dark: var(--black-80-alpha);
+  --color-overlay-light: var(--black-20-alpha);
+  --color-overlay-medium: var(--black-60-alpha);
+
   /* Focus Colors */
   --color-focus-clarity: var(--focus-blue-100);
   --color-focus-ambiguous: var(--focus-blue-30-alpha);


### PR DESCRIPTION
https://github.com/openameba/spindle/blob/4b37fb71b10880233a7e4ca3ce7f8a4d67b4cc8e/packages/spindle-tokens/tokens/color/theme-light.json#L166-L177

上記でトークン化はされているのでameba-color-palette.cssの方にoverlayで使用するcolorを追加しました。