### PR TITLE
chore: create release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: releaseing
+name: releasing
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: releaseing
+
+on:
+  push:
+    branches:
+      - release/major
+      - release/minor
+      - release/patch
+      - release/premajor
+      - release/preminor
+      - release/prepatch
+      - release/prerelease
+
+jobs:
+  releaseing:
+    name: releaseing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: 16
+      - name: Set git user
+        run: |
+          git config --global user.email "<>"
+          git config --global user.name "openameba"
+      - name: Log in to npm
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          npm whoami
+      - name: Extract branch from git ref
+        run: |
+          echo "::set-output name=name::${GITHUB_REF#refs/*/}"
+          echo "::set-output name=version::${GITHUB_REF##*/}"
+        id: extract_branch
+      - name: Versioning
+        run: npm version ${{ steps.extract_branch.outputs.version }}
+      - name: Publish to npm
+        run: npm publish
+      - name: Push updates
+        run: |
+          git push origin ${{ steps.extract_branch.outputs.name }}
+          git push origin --tags
+      - name: Create Pull Request
+        run: >
+          curl
+          -X POST
+          -H "Accept: application/vnd.github.v3+json"
+          -H "Authorization: token ${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          https://api.github.com/repos/${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}/pulls
+          -d '{"head":"${{ steps.extract_branch.outputs.name }}","base":"${{ github.event.repository.default_branch }}","title":"chore(release): publish"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - release/prerelease
 
 jobs:
-  releaseing:
+  releasing:
     name: releaseing
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   releasing:
-    name: releaseing
+    name: releasing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
ちょくちょく更新が入るのでGitHub Actionsでnpmパブリッシュできるようにしました。フローとしては以下の通りで、今のところSpindleのものと似せています。

- パブリッシュしたいブランチ(おそらくほぼmain)から `release/*` を作りpush
- GitHub Actionsでバージョン更新、npmパブリッシュ、[PR作成](https://github.com/openameba/ameba-color-palette.css/pull/74)する
- 作成されたPR取り込む
- 作成された[Tag](https://github.com/openameba/ameba-color-palette.css/releases/tag/v4.8.0-0)に対し、リリースノートを記載する

ドキュメントは別途更新します。
