### PR TITLE
refactor: rename data-theme to data-color-scheme

### DIFF
--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -176,7 +176,8 @@
 }
 
 /* You can apply dark theme even when prefers-color-scheme is not dark.  */
-:root[data-theme="dark"] {
+:root[data-theme="dark"],
+:root[data-color-scheme="dark"] {
   /* Background Colors */
   --color-background: var(--gray-100);
 
@@ -225,7 +226,9 @@
 @media (prefers-color-scheme: dark) {
   /* You can disable dark theme even when prefers-color-scheme is dark.  */
   :root:not([data-theme]),
-  :root[data-theme="dark"] {
+  :root:not([data-color-scheme]),
+  :root[data-theme="dark"],
+  :root[data-color-scheme="dark"] {
     /* Background Colors */
     --color-background: var(--gray-100);
 


### PR DESCRIPTION
Theme switchなどでテーマを上書きする際のカスタム属性名を`data-color-scheme`に変更しました。themeだと意味が広がりすぎてしまうので、`prefers-color-scheme` を上書きというニュアンスの命名にしました。

[Ameba Accessibility Guidelines](https://a11y-guidelines.ameba.design/)で`data-theme`を利用しているので、置き換えが終わったらこちらのコードから削除します。
