### PR TITLE
feat: add expressive-pink-50 to a text color

### DIFF
--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -96,7 +96,8 @@
   --expressive-lavender: #755ce6;
   --expressive-orange: #e6815c;
   --expressive-yellow: #e6ac5c;
-  --expressive-pink: #e6456a;
+  --expressive-pink-40: #e6456a;
+  --expressive-pink-50: #e02c53;
 
   /* Third Party Colors */
   --facebook-blue: #1877f2;
@@ -140,6 +141,7 @@
   --color-text-accent-primary: var(--primary-green-80);
   --color-text-accent-secondary: var(--secondary-green-80);
   --color-text-caution: var(--caution-red-100);
+  --color-text-expressive-pink: var(--expressive-pink-50);
 
   /* Highlight Colors */
   --color-highlight-error: var(--caution-red-20-alpha);
@@ -155,7 +157,7 @@
   --color-object-accent-secondary: var(--secondary-green-70);
   --color-object-caution: var(--caution-red-100);
   --color-object-high-emphasis-inverse: var(--white-100);
-  --color-object-expressive-pink: var(--expressive-pink);
+  --color-object-expressive-pink: var(--expressive-pink-40);
 
   /* Overlay Colors */
   --color-overlay-dark: var(--black-80-alpha);


### PR DESCRIPTION
spindle-tokenにある通り、[expressive colorにもtokenが定義されています](https://github.com/openameba/spindle/blob/main/packages/spindle-tokens/tokens/color/primitive.json#L445-L456)

現在`expressive-pink`として定義されているcolorは文字に利用する場合、（白背景に対する）コントラスト比がアクセシビリティのAA基準を満たすことができません

そこでtokenにあるパターンを追加し、新たに変数`--color-text-expressive-pink`を追加しました

**注意事項**：--objectの方でなく、変数`--expressive-pink`を直接参照している実装箇所は`--expressive-pink-40`ないし` --color-object-expressive-pink`に置き換えていただく必要があります

<img width="185" alt="" src="https://user-images.githubusercontent.com/92707228/192756659-210cbebd-a2c9-4320-8f6a-71b971db59ac.png">



