### PR TITLE
Feat/change x icon color

### DIFF
--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -195,6 +195,7 @@
   --color-third-party-twitter-blue: var(--twitter-blue);
   --color-third-party-twitter-white: var(--twitter-white);
   --color-third-party-x-blue: var(--x-blue); /* deprecated. --x-blue- is undefined. specifying it won't change the color. */
+  --color-third-party-x-black: var(--x-black);
   --color-third-party-x-white: var(--x-white);
   --color-third-party-instagram-pink: var(--instagram-pink);
   --color-third-party-apple-black: var(--apple-black);

--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -194,7 +194,7 @@
   --color-third-party-facebook-white: var(--facebook-white);
   --color-third-party-twitter-blue: var(--twitter-blue);
   --color-third-party-twitter-white: var(--twitter-white);
-  --color-third-party-x-blue: var(--x-blue);
+  --color-third-party-x-blue: var(--x-blue); /* deprecated. --x-blue- is undefined. specifying it won't change the color. */
   --color-third-party-x-white: var(--x-white);
   --color-third-party-instagram-pink: var(--instagram-pink);
   --color-third-party-apple-black: var(--apple-black);


### PR DESCRIPTION
## 概要
Xアイコンの色指定が間違っていたため`--color-third-party-x-blue`を指定しても色が適用されない状態になっていました。
正しい変数を追加しつつ、コメントでdeprecatedを記載しました。

追加した変数名は https://github.com/openameba/spindle/pull/965 のdesign tokenに合わせて修正しています。