### PR TITLE
ci: remove --assignee argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Create Pull Request
         run: >
           gh pr create
-          --assignee
           --base "${{ github.event.repository.default_branch }}"
           --body ''
           --head "${{ github.ref_name }}"


### PR DESCRIPTION
リリースのワークフローでPull-requestを出す際にエラーが出ていたのを修正しました。
おそらく `--assignee` を値を指定し忘れていて `--base` が値として使われているのではないかと……