### PR TITLE
border-high-emphasisの色を更新

### DIFF
--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -194,7 +194,7 @@
 
   /* Border Colors */
   --color-border-strong-emphasis: var(--gray-100);
-  --color-border-high-emphasis: var(--gray-60-alpha);
+  --color-border-high-emphasis: var(--gray-50-alpha);
   --color-border-medium-emphasis: var(--gray-30-alpha);
   --color-border-low-emphasis: var(--gray-10-alpha);
   --color-border-accent-primary: var(--primary-green-70);


### PR DESCRIPTION
### 概要
下記スクリーンショットのようにコントラスト比的にalpha-60より50の方が良さそうということでデザイナー側から修正要望があり対応しました。

<img width="600" alt="" src="https://github.com/user-attachments/assets/8befb3b8-3695-4d6d-928d-c1ead95cf528" />
