### PR TITLE
neutralボタンのactive色を変更

### DIFF
--- a/ameba-color-palette.css
+++ b/ameba-color-palette.css
@@ -174,7 +174,7 @@
   /* Active Colors */
   --color-active-contained-button: var(--primary-green-100);
   --color-active-outlined-button: var(--primary-green-5);
-  --color-active-neutral-button: var(--gray-10-alpha);
+  --color-active-neutral-button: var(--gray-20-alpha);
   --color-active-lighted-button: var(--primary-green-10);
   --color-active-danger-button: var(--caution-red-5-alpha);
 


### PR DESCRIPTION
### 概要
[feat(spindle-tokens): update design tokens](https://github.com/openameba/spindle/pull/1341/files)
の更新でアップデートあったのでameba-color-palette側にも取り込みました。